### PR TITLE
Add optional iter argmust to DCC.m

### DIFF
--- a/external/DCC_toolbox/DCCcode/DCC.m
+++ b/external/DCC_toolbox/DCCcode/DCC.m
@@ -173,7 +173,7 @@ fprintf('Running %d pairs: Estimated complete in %s, %05d', n, display_string, i
 for j=1:(p-1)  
     for k=(j+1):p
   
-        [ Ctmat ] = DCCsimple([Dat(:,j) Dat(:,k)]); 
+        [ Ctmat ] = DCCsimple([Dat(:,j) Dat(:,k)], iter); 
         C(j,k,:) = Ctmat(1,2,:); 
         C(k,j,:) = Ctmat(1,2,:); 
 

--- a/external/DCC_toolbox/DCCcode/DCC.m
+++ b/external/DCC_toolbox/DCCcode/DCC.m
@@ -85,6 +85,7 @@ function C = DCC(Dat, varargin)
 
 dowhiten = 0;
 doresid = 0;
+iter=1000;
 
 % optional inputs with default values
 for i = 1:length(varargin)
@@ -96,6 +97,10 @@ for i = 1:length(varargin)
             case {'resid', 'residualize', 'X', 'model'}
                 doresid = 1; 
                 X = varargin{i + 1}; varargin{i + 1} = [];
+
+            case 'iter' % handle new iter arg
+                iter = varargin{i + 1}; % assign input value
+                varargin{i + 1} = []; % clear the next slot
                 
             otherwise, warning(['Unknown input string option:' varargin{i}]);
         end

--- a/external/DCC_toolbox/DCCcode/DCCsimple.m
+++ b/external/DCC_toolbox/DCCcode/DCCsimple.m
@@ -1,4 +1,4 @@
-function [Ct, Ht] = DCC(dat)
+function [Ct, Ht] = DCC(dat,iter)
 % function [Ct, Ht] = DCC(dat)
 %
 % Estimate a multivariate GARCH model using the DCC estimator of Engle and Sheppard
@@ -16,9 +16,13 @@ function [Ct, Ht] = DCC(dat)
 % File created by Martin Lindquist on 07/22/14
 % Last update: 07/22/14
 
+if isempty(iter)
+    iter=1000;
+end
+
 [T,p] = size(dat);
 
-[~, ~, Ht] = dcc_mvgarch(dat,1,1,1,1);        % Ht is the dyanamic covariance matrix
+[~, ~, Ht] = dcc_mvgarch(dat,1,1,1,1,iter);        % Ht is the dyanamic covariance matrix
 
 % Compute dynamic correlation matrix Ct
 Ct = Ht;

--- a/external/DCC_toolbox/DCCcode/dcc_mvgarch.m
+++ b/external/DCC_toolbox/DCCcode/dcc_mvgarch.m
@@ -1,4 +1,4 @@
-function [parameters, loglikelihood, Ht, Qt,  stdresid, likelihoods, stderrors, A,B, jointscores]=dcc_mvgarch(data,dccP,dccQ,archP,garchQ)
+function [parameters, loglikelihood, Ht, Qt,  stdresid, likelihoods, stderrors, A,B, jointscores]=dcc_mvgarch(data,dccP,dccQ,archP,garchQ,iter)
 % PURPOSE:
 %        Estimates a multivariate GARCH model using the DCC estimator of Engle and Sheppard
 % 
@@ -73,12 +73,16 @@ elseif length(garchQ)==1
     garchQ=ones(1,k)*garchQ;
 end
 
+if isempty(iter)
+    iter=1000;
+end
+
 
 % Now lest do the univariate garching using fattailed_garch as it's faster then garchpq
 stdresid=data;
 options=optimset('fmincon');
-options=optimset(options,'Display','off','Diagnostics','off','MaxFunEvals',1000*max(archP+garchQ+1),'MaxIter',1000*max(archP+garchQ+1),'LargeScale','off','MaxSQPIter',1000);
-options  =  optimset(options , 'MaxSQPIter' , 1000);
+options=optimset(options,'Display','off','Diagnostics','off','MaxFunEvals',iter*max(archP+garchQ+1),'MaxIter',iter*max(archP+garchQ+1),'LargeScale','off','MaxSQPIter',iter);
+options  =  optimset(options , 'MaxSQPIter' , iter);
 for i=1:k
     if doverbose, fprintf(1,'Estimating GARCH model for Series %d\n',i); end
     [univariate{i}.parameters, univariate{i}.likelihood, univariate{i}.stderrors, univariate{i}.robustSE, univariate{i}.ht, univariate{i}.scores] ... 


### PR DESCRIPTION
Optional argument `iter` to DCC() allows users to increase max number of iterations. Default set to current value of 1000.