### PR TITLE
Expand Python implementation note into a dedicated README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 *As of March 2026 there is now a python wrapper for the matlab-toolbox, see [here](https://github.com/HopkinsPsychedelic/CopBET_Python)*
 
-*As of April 2026 there is now a python implementation for this toolbox, see the copbet_py folder. DCC is not implemented in python.*
+## Python implementation
+
+As of April 2026, a Python translation of CopBET is available in the `copbet_py/` folder of this repository (contributed by Drummond McCulloch). It implements 12 of the 13 entropy/complexity measures — **DCC entropy is not yet implemented in Python**. All functions accept a list of `(T × N)` NumPy arrays (one per session) and return entropy values as NumPy arrays.
+
+See [`copbet_py/README.md`](copbet_py/README.md) for installation instructions, usage examples, and a full comparison with the MATLAB implementation.
 
 The Copenhagen Brain Entropy Toolbox is a MATLAB toolbox that provides a collection of functions for evaluating 12 different entropy metrics described in the paper [Navigating the chaos of psychedelic neuroimaging: A multi-metric evaluation of acute psilocybin effects on brain entropy" by Drummond McCulloch, Anders S Olsen et al (MedRxiv)](https://www.medrxiv.org/content/10.1101/2023.07.03.23292164v3). This toolbox allows researchers to analyze and quantify the entropy of fMRI-recorded brain activity using various methods. 
 
@@ -114,3 +118,4 @@ Copyright (C) 2023  Drummond E-Wen McCulloch & Anders Stevnhoved Olsen
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see http://www.gnu.org/licenses/.
+


### PR DESCRIPTION
The single italic line noting the Python implementation has been expanded into a proper section. It lists the 12 implemented measures, clearly notes that DCC entropy is not yet available in Python, and links to the `copbet_py/README.md` for full details.